### PR TITLE
Small fixes for system::selbooleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Manage Linux system resources and services from hiera configuration.
 * *ntp*: configure NTP servers in /etc/ntp.conf
 * *packages*: manage system packages
 * *schedules*: determine when resource config should not be applied and how often
+* *selbooleans*: manage SELinux booleans
 * *services*: manage system services
 * *sshd*: manage configuration in /etc/ssh/sshd_config including subsystems like sftp
 * *sysconfig*: manage files under /etc/sysconfig: clock, i18n, keyboard, puppet-dashboard, puppet, puppetmaster, selinux

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class system (
   }
 
   class { '::system::selbooleans':
-    config => $config['selbooleana'],
+    config => $config['selbooleans'],
     stage  => first,
   }
 

--- a/manifests/selbooleans.pp
+++ b/manifests/selbooleans.pp
@@ -2,7 +2,7 @@ class system::selbooleans (
   $config   = undef,
   $schedule = $::system::schedule,
 ) {
-  if $::selinux == true {
+  if $::selinux == "true" {
     $defaults = {
       schedule => $schedule,
     }


### PR DESCRIPTION
These commits fix the following issues with system::selbooleans:

* Typo in system::init (sebooleana)
* Incorrectly checks if SELinux is enabled via "if $::selinux == true", which doesn't work because facter facts are always strings.
* Not in the TOC in README.md

Tested on Centos 6.5