### PR TITLE
Stop using meta parameter as a variable

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -1,9 +1,9 @@
 class system::augeas (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(augeas, $config, $defaults)

--- a/manifests/crontabs.pp
+++ b/manifests/crontabs.pp
@@ -1,10 +1,10 @@
 class system::crontabs (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
     user     => 'root',
   }
   if $config {

--- a/manifests/execs.pp
+++ b/manifests/execs.pp
@@ -1,9 +1,9 @@
 class system::execs (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(exec, $config, $defaults)

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -1,6 +1,6 @@
 define system::fact (
   $value    = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
   $type     = 'yaml',
   $ttl      = undef,
 ) {
@@ -10,7 +10,7 @@ define system::fact (
   if is_array($value) {
     $resource_name = "${var}%index%"
     $parameters = {
-      schedule => $schedule,
+      schedule => $sys_schedule,
       type     => $type,
       ttl      => $ttl,
     }

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -1,7 +1,7 @@
 class system::facts (
   $config   = undef,
   $cleanold = false,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if ! defined(File['/etc/facter']) {
     file { '/etc/facter':
@@ -33,7 +33,7 @@ class system::facts (
     order    => '01',
   }
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources('system::fact', $config, $defaults)
@@ -55,7 +55,7 @@ class system::facts (
     exec { "fact-remove-sysconfig-puppet":
       command  => "/usr/bin/perl -pi -e 's/^\s*#?\s*(export )?FACTER_.*?=.*?$//' /etc/sysconfig/puppet",
       onlyif   => '/bin/grep -q FACTER_ /etc/sysconfig/puppet',
-      schedule => $schedule,
+      schedule => $sys_schedule,
     }
   }
 }

--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -1,10 +1,10 @@
 class system::files (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(file, $config, $defaults)

--- a/manifests/groups.pp
+++ b/manifests/groups.pp
@@ -1,11 +1,11 @@
 class system::groups (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
   $real     = false,
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $real {
     $type = 'group'

--- a/manifests/groups/realize.pp
+++ b/manifests/groups/realize.pp
@@ -1,6 +1,6 @@
 class system::groups::realize (
   $groups   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if $groups {
     realize(Group[$groups])

--- a/manifests/hosts.pp
+++ b/manifests/hosts.pp
@@ -1,10 +1,10 @@
 class system::hosts (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(host, $config, $defaults)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class system (
   $config   = {},
-  $schedule = undef,
+  $sys_schedule = undef,
 ) {
   # Ensure that files and directories are created before
   # other resources (like mounts) that may depend on them

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -1,13 +1,13 @@
 class system::limits (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if $config {
     include limits
     class { '::limits':
       config    => $config,
       use_hiera => false,
-      #schedule => $schedule,
+      #schedule => $sys_schedule,
     }
   }
   else {
@@ -17,7 +17,7 @@ class system::limits (
       class { '::limits':
         config    => $hiera_config,
         use_hiera => false,
-        #schedule => $schedule,
+        #schedule => $sys_schedule,
       }
     }
   }

--- a/manifests/mail.pp
+++ b/manifests/mail.pp
@@ -1,9 +1,9 @@
 class system::mail (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     $aliases   = $config['aliases']
@@ -28,12 +28,12 @@ class system::mail (
           context  => '/files/etc/postfix/main.cf',
           changes  => [ "set relayhost ${relayhost}" ],
           notify   => Service['postfix'],
-          schedule => $schedule,
+          schedule => $sys_schedule,
         }
         service { 'postfix':
           ensure   => 'running',
           enable   => true,
-          schedule => $schedule,
+          schedule => $sys_schedule,
         }
       }
       default: {

--- a/manifests/mounts.pp
+++ b/manifests/mounts.pp
@@ -1,11 +1,11 @@
 class system::mounts (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     atboot   => true,
     ensure   => 'mounted',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(mount, $config, $defaults)

--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -1,6 +1,6 @@
 class system::ntp (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if $config {
     if $config['servers'] {

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,10 +1,10 @@
 class system::packages (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure   => 'installed',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(package, $config, $defaults)

--- a/manifests/selbooleans.pp
+++ b/manifests/selbooleans.pp
@@ -1,10 +1,10 @@
 class system::selbooleans (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if $::selinux == true {
     $defaults = {
-      schedule => $schedule,
+      schedule => $sys_schedule,
     }
     if $config {
       create_resources(selboolean, $config, $defaults)

--- a/manifests/services.pp
+++ b/manifests/services.pp
@@ -1,12 +1,12 @@
 class system::services (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure     => 'running',
     hasrestart => true,
     hasstatus  => true,
-    schedule   => $schedule,
+    schedule   => $sys_schedule,
   }
   if $config {
     create_resources(service, $config, $defaults)

--- a/manifests/sshd.pp
+++ b/manifests/sshd.pp
@@ -1,10 +1,10 @@
 class system::sshd (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
   $sync_host_keys = true
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     include augeasproviders

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -1,39 +1,39 @@
 class system::sysconfig (
   $config   = {},
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   class { '::system::sysconfig::clock':
     config   => $config['clock'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::i18n':
     config   => $config['i18n'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::keyboard':
     config   => $config['keyboard'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::puppetdashboard':
     config   => $config['puppetdashboard'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::puppetmaster':
     config   => $config['puppetmaster'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::puppet':
     config   => $config['puppet'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 
   class { '::system::sysconfig::selinux':
     config   => $config['selinux'],
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
 }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -1,9 +1,9 @@
 class system::sysctl (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     include augeasproviders

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -3,13 +3,13 @@ define system::template(
   $owner    = 'root',
   $group    = 'root',
   $mode     = undef,
-  $schedule = 'always',
+  $sys_schedule = 'always',
 ) {
   file { $title:
     owner    => $owner,
     group    => $group,
     mode     => $mode,
-    schedule => $schedule,
+    schedule => $sys_schedule,
     content  => template($template),
   }
 }

--- a/manifests/templates.pp
+++ b/manifests/templates.pp
@@ -1,9 +1,9 @@
 class system::templates (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources('system::template', $config, $defaults)

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -1,11 +1,11 @@
 class system::users (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
   $real     = false,
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
     shell    => '/bin/bash'
   }
   if $real {

--- a/manifests/users/realize.pp
+++ b/manifests/users/realize.pp
@@ -1,6 +1,6 @@
 class system::users::realize (
   $users    = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   if $users {
     realize(User[$users])

--- a/manifests/yumgroup.pp
+++ b/manifests/yumgroup.pp
@@ -2,7 +2,7 @@
 define system::yumgroup(
   $ensure   = 'present',
   $optional = false,
-  $schedule = 'daily',
+  $sys_schedule = 'daily',
   $usecache = true
 ) {
   $pkg_types_arg = $optional ? {
@@ -19,7 +19,7 @@ define system::yumgroup(
         command  => "/usr/bin/yum -y groupinstall ${pkg_types_arg} '${name}'",
         unless   => "/usr/bin/yum $cache grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\w/o; print' | /bin/grep -qw '${name}'",
         timeout  => 600,
-        schedule => $schedule,
+        schedule => $sys_schedule,
       }
     }
     absent: {
@@ -27,7 +27,7 @@ define system::yumgroup(
         command  => "/usr/bin/yum -y groupremove ${pkg_types_arg} '${name}'",
         unless   => "/usr/bin/yum $cache grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\w/o; print' | /bin/grep -qw '${name}'",
         timeout  => 600,
-        schedule => $schedule,
+        schedule => $sys_schedule,
       }
     }
     default: {

--- a/manifests/yumgroups.pp
+++ b/manifests/yumgroups.pp
@@ -1,10 +1,10 @@
 class system::yumgroups (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     ensure   => 'present',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources('system::yumgroup', $config, $defaults)

--- a/manifests/yumrepos.pp
+++ b/manifests/yumrepos.pp
@@ -1,11 +1,11 @@
 class system::yumrepos (
   $config   = undef,
-  $schedule = $::system::schedule,
+  $sys_schedule = 'always',
 ) {
   $defaults = {
     enabled  => '1',
     gpgcheck => '1',
-    schedule => $schedule,
+    schedule => $sys_schedule,
   }
   if $config {
     create_resources(yumrepo, $config, $defaults)


### PR DESCRIPTION
Puppet has introduced stronger checks and now this module throws warnings because it is using the metaparameter schedule as a variable name. All I've done is rename the variable schedule to sys_schedule and provided 'always' as a default.